### PR TITLE
fix minor errors in types

### DIFF
--- a/crates/starfish-core/src/types.rs
+++ b/crates/starfish-core/src/types.rs
@@ -316,6 +316,22 @@ impl VerifiedStatementBlock {
 
     pub fn from_storage_to_transmission(&self, own_id: AuthorityIndex) -> Self {
         if own_id != self.reference.authority {
+            if let Some((_, position)) = self.encoded_shard().as_ref() {
+                if *position != own_id as usize {
+                    return Self {
+                        reference: self.reference,
+                        includes: self.includes.clone(),
+                        acknowledgement_statements: self.acknowledgement_statements.clone(),
+                        meta_creation_time_ns: self.meta_creation_time_ns,
+                        epoch_marker: self.epoch_marker,
+                        signature: self.signature,
+                        statements: None,
+                        encoded_shard: None,
+                        merkle_proof_encoded_shard: None,
+                        transactions_commitment: self.transactions_commitment,
+                    };
+                }
+            }
             Self {
                 reference: self.reference,
                 includes: self.includes.clone(),

--- a/crates/starfish-core/src/types.rs
+++ b/crates/starfish-core/src/types.rs
@@ -130,7 +130,7 @@ pub struct CachedStatementBlock {
     signature: SignatureBytes,
     // It could be either a vector of BaseStatement or None
     statements: Option<Vec<BaseStatement>>,
-    // It could be a pair of encoded shard and position or None -- it is incorrect
+    // Contains Some(Shard) if the shard is available, or None if the shard is not available.
     encoded_statements: Vec<Option<Shard>>,
     // This is Some only when the above has one some
     merkle_proof_encoded_shard: Option<Vec<u8>>,


### PR DESCRIPTION
### Description of change

In the creation of VerifiedStatementBlock for transmission from storage encoded_shard remove extra code which processes impossible situation.
Also, in to_cached_block there was one extra None in the vector.