### PR TITLE
fix: improve single-region monitoring scrapes and gzip metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -132,6 +132,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
+name = "async-compression"
+version = "0.4.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0f9ee0f6e02ffd7ad5816e9464499fba7b3effd01123b515c41d1697c43dad1"
+dependencies = [
+ "compression-codecs",
+ "compression-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -949,6 +961,23 @@ name = "colorchoice"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+
+[[package]]
+name = "compression-codecs"
+version = "0.4.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb7b51a7d9c967fc26773061ba86150f19c50c0d65c887cb1fbe295fd16619b7"
+dependencies = [
+ "compression-core",
+ "flate2",
+ "memchr",
+]
+
+[[package]]
+name = "compression-core"
+version = "0.4.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75984efb6ed102a0d42db99afb6c1948f0380d1d91808d5529916e6c08b49d8d"
 
 [[package]]
 name = "constant_time_eq"
@@ -3439,6 +3468,7 @@ dependencies = [
  "test-case",
  "tidehunter",
  "tokio",
+ "tower-http",
  "tracing",
  "zeroize",
  "zstd",
@@ -3846,13 +3876,17 @@ version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
+ "async-compression",
  "bitflags",
  "bytes",
+ "futures-core",
  "futures-util",
  "http 1.4.0",
  "http-body 1.0.1",
  "iri-string",
  "pin-project-lite",
+ "tokio",
+ "tokio-util",
  "tower",
  "tower-layer",
  "tower-service",

--- a/crates/orchestrator/assets/settings-template.yml
+++ b/crates/orchestrator/assets/settings-template.yml
@@ -13,8 +13,15 @@ repository:
 # spot: true
 # External monitoring server (optional). Uses this server for Prometheus +
 # Grafana instead of allocating a cloud instance. Accepts [user@]host format.
-# The server must authorize the same public key as ssh_private_key_file.
+# The server must authorize the same public key as ssh_private_key_file and
+# must be able to reach the validator metrics endpoints selected by the
+# benchmark network mode. Single-region runs use private IPs; multi-region
+# runs use public IPs.
 # monitoring_server: root@monitor.example.com
+# Scrape cadence shared by benchmark measurements and Prometheus monitoring.
+# The monitoring stack enforces a minimum of 5 seconds and keeps node-exporter
+# on a slower cadence to reduce load on large committees.
+# scrape_interval: 15
 # Pre-built binary (optional). Skips source compilation on remote machines.
 # URL downloads via curl; local path SCPs to all machines.
 # pre_built_binary: "https://github.com/iotaledger/starfish/releases/download/nightly/starfish-linux-amd64"

--- a/crates/orchestrator/assets/settings-template.yml
+++ b/crates/orchestrator/assets/settings-template.yml
@@ -13,11 +13,13 @@ repository:
 # spot: true
 # External monitoring server (optional). Uses this server for Prometheus +
 # Grafana instead of allocating a cloud instance. Accepts [user@]host format.
-# The server must authorize the same public key as ssh_private_key_file and
-# must be able to reach the validator metrics endpoints selected by the
-# benchmark network mode. Single-region runs use private IPs; multi-region
-# runs use public IPs.
+# The server must authorize the same public key as ssh_private_key_file.
+# External monitoring defaults to scraping validator public IPs so a host
+# outside AWS can still collect metrics.
 # monitoring_server: root@monitor.example.com
+# Override the scrape-address policy when the monitoring host can reach the
+# validator private network directly.
+# monitoring_scrape_public_ip: false
 # Scrape cadence shared by benchmark measurements and Prometheus monitoring.
 # The monitoring stack enforces a minimum of 5 seconds and keeps node-exporter
 # on a slower cadence to reduce load on large committees.

--- a/crates/orchestrator/readme.md
+++ b/crates/orchestrator/readme.md
@@ -246,9 +246,18 @@ The value accepts `[user@]host` format. When set, the orchestrator:
 - Never destroys the external server on `testbed destroy`.
 
 The server must be reachable via SSH with the same private key configured in
-`ssh_private_key_file`. Hostnames are resolved via DNS. When running with
-`--use-internal-ip-addresses`, the server must be able to reach the validators'
-private IPs (e.g., it should be in the same VPC).
+`ssh_private_key_file`. Hostnames are resolved via DNS. The monitoring server
+scrapes whichever validator addresses the benchmark itself uses:
+
+- Single-region runs scrape private IPs, so the monitoring host must be inside
+  the same VPC or another network that can route to those addresses.
+- Multi-region runs scrape public IPs, so the validator metrics ports must be
+  reachable from the monitoring host.
+
+The monitoring scrape cadence is controlled by `scrape_interval` in
+`settings.yml` and no longer slows down automatically as the committee grows.
+Prometheus uses one shared validator job and one shared node-exporter job so
+large committees remain manageable.
 
 ### Collecting monitoring data locally
 

--- a/crates/orchestrator/readme.md
+++ b/crates/orchestrator/readme.md
@@ -246,13 +246,16 @@ The value accepts `[user@]host` format. When set, the orchestrator:
 - Never destroys the external server on `testbed destroy`.
 
 The server must be reachable via SSH with the same private key configured in
-`ssh_private_key_file`. Hostnames are resolved via DNS. The monitoring server
-scrapes whichever validator addresses the benchmark itself uses:
+`ssh_private_key_file`. Hostnames are resolved via DNS. By default, external
+monitoring servers scrape validator public IPs so a machine outside AWS can
+still collect metrics while validators themselves use private IPs for
+single-region traffic. If your monitoring server is inside the same VPC or can
+otherwise route to validator private IPs, override that behavior in
+`settings.yml`:
 
-- Single-region runs scrape private IPs, so the monitoring host must be inside
-  the same VPC or another network that can route to those addresses.
-- Multi-region runs scrape public IPs, so the validator metrics ports must be
-  reachable from the monitoring host.
+```yml
+monitoring_scrape_public_ip: false
+```
 
 The monitoring scrape cadence is controlled by `scrape_interval` in
 `settings.yml` and no longer slows down automatically as the committee grows.

--- a/crates/orchestrator/src/monitor.rs
+++ b/crates/orchestrator/src/monitor.rs
@@ -24,6 +24,7 @@ pub struct Monitor {
     nodes: Vec<Instance>,
     ssh_manager: SshConnectionManager,
     working_dir: PathBuf,
+    scrape_over_public_ip: bool,
 }
 
 impl Monitor {
@@ -33,12 +34,14 @@ impl Monitor {
         nodes: Vec<Instance>,
         ssh_manager: SshConnectionManager,
         working_dir: PathBuf,
+        scrape_over_public_ip: bool,
     ) -> Self {
         Self {
             instance,
             nodes,
             ssh_manager,
             working_dir,
+            scrape_over_public_ip,
         }
     }
 
@@ -71,7 +74,13 @@ impl Monitor {
     ) -> MonitorResult<()> {
         self.ensure_working_dir().await?;
 
-        let config = Prometheus::configuration(self.nodes.clone(), protocol_commands, parameters);
+        let mut scrape_parameters = parameters.clone();
+        if self.scrape_over_public_ip {
+            scrape_parameters.use_internal_ip_address = false;
+        }
+
+        let config =
+            Prometheus::configuration(self.nodes.clone(), protocol_commands, &scrape_parameters);
         let remote_config: PathBuf = "prometheus.yml".into();
         let remote_config_path = self.working_dir.join(&remote_config);
 

--- a/crates/orchestrator/src/monitor.rs
+++ b/crates/orchestrator/src/monitor.rs
@@ -7,6 +7,7 @@ use std::{
     net::SocketAddr,
     path::{Path, PathBuf},
     process::Command,
+    time::Duration,
 };
 
 use crate::{
@@ -23,7 +24,6 @@ pub struct Monitor {
     nodes: Vec<Instance>,
     ssh_manager: SshConnectionManager,
     working_dir: PathBuf,
-    scrape_over_public_ip: bool,
 }
 
 impl Monitor {
@@ -33,14 +33,12 @@ impl Monitor {
         nodes: Vec<Instance>,
         ssh_manager: SshConnectionManager,
         working_dir: PathBuf,
-        scrape_over_public_ip: bool,
     ) -> Self {
         Self {
             instance,
             nodes,
             ssh_manager,
             working_dir,
-            scrape_over_public_ip,
         }
     }
 
@@ -73,13 +71,7 @@ impl Monitor {
     ) -> MonitorResult<()> {
         self.ensure_working_dir().await?;
 
-        let mut scrape_parameters = parameters.clone();
-        if self.scrape_over_public_ip {
-            scrape_parameters.use_internal_ip_address = false;
-        }
-
-        let config =
-            Prometheus::configuration(self.nodes.clone(), protocol_commands, &scrape_parameters);
+        let config = Prometheus::configuration(self.nodes.clone(), protocol_commands, parameters);
         let remote_config: PathBuf = "prometheus.yml".into();
         let remote_config_path = self.working_dir.join(&remote_config);
 
@@ -170,6 +162,9 @@ impl Monitor {
 pub struct Prometheus;
 
 impl Prometheus {
+    const MIN_SCRAPE_INTERVAL_SECS: u64 = 5;
+    const VALIDATOR_SAMPLE_LIMIT: usize = 50_000;
+    const NODE_EXPORTER_SAMPLE_LIMIT: usize = 20_000;
     /// The default prometheus configuration path.
     const DEFAULT_PROMETHEUS_CONFIG_PATH: &'static str = "/etc/prometheus/prometheus.yml";
     #[cfg(test)]
@@ -209,13 +204,27 @@ impl Prometheus {
         I: IntoIterator<Item = Instance>,
         P: ProtocolMetrics,
     {
-        let nodes_metrics_path = protocol.nodes_metrics_path(nodes, parameters);
-        let mut config = vec![Self::global_configuration(nodes_metrics_path.len())];
+        let targets: Vec<_> = protocol
+            .nodes_metrics_path(nodes, parameters)
+            .into_iter()
+            .enumerate()
+            .map(|(i, (_, nodes_metrics_path))| {
+                Self::parse_scrape_target(&format!("node-{i}"), &nodes_metrics_path)
+            })
+            .collect();
+        let scrape_interval = parameters.settings.scrape_interval;
+        let mut config = vec![Self::global_configuration(scrape_interval)];
 
-        for (i, (_, nodes_metrics_path)) in nodes_metrics_path.into_iter().enumerate() {
-            let id = format!("node-{i}");
-            let scrape_config = Self::scrape_configuration(&id, &nodes_metrics_path);
-            config.push(scrape_config);
+        if let Some(metrics_path) = targets.first().map(|target| target.metrics_path.as_str()) {
+            config.push(Self::validator_scrape_configuration(
+                metrics_path,
+                &targets,
+                scrape_interval,
+            ));
+            config.push(Self::node_exporter_scrape_configuration(
+                &targets,
+                Self::node_exporter_scrape_interval(scrape_interval),
+            ));
         }
 
         config.join("\n")
@@ -243,13 +252,11 @@ impl Prometheus {
 
     /// Generate the global prometheus configuration.
     /// NOTE: The configuration file is a yaml file so spaces are important.
-    fn global_configuration(nodes: usize) -> String {
-        let scrape_secs = (nodes / 6).max(5);
-        let timeout_secs = (scrape_secs / 2).max(3);
+    fn global_configuration(scrape_interval: Duration) -> String {
+        let scrape_secs = Self::scrape_interval_secs(scrape_interval);
         [
             "global:".to_string(),
             format!("  scrape_interval: {scrape_secs}s"),
-            format!("  scrape_timeout: {timeout_secs}s"),
             format!("  evaluation_interval: {scrape_secs}s"),
             "rule_files:".to_string(),
             format!("  - {}", Self::RECORDING_RULES_PATH),
@@ -285,33 +292,101 @@ groups:
         .to_string()
     }
 
-    /// Generate the prometheus configuration from the given metrics path.
-    /// NOTE: The configuration file is a yaml file so spaces are important.
-    fn scrape_configuration(id: &str, nodes_metrics_path: &str) -> String {
-        let parts: Vec<_> = nodes_metrics_path.split('/').collect();
-        let address = parts[0].parse::<SocketAddr>().unwrap();
-        let ip = address.ip();
-        let port = address.port();
-        let path = parts[1];
-
-        [
-            &format!("  - job_name: instance-{id}"),
-            &format!("    metrics_path: /{path}"),
-            "    honor_labels: true",
-            "    static_configs:",
-            "      - targets:",
-            &format!("        - {ip}:{port}"),
-            "        labels:",
-            &format!("          validator: {id}"),
-            &format!("  - job_name: instance-node-exporter-{id}"),
-            "    static_configs:",
-            "      - targets:",
-            &format!("        - {ip}:9200"),
-            "        labels:",
-            &format!("          validator: {id}"),
-        ]
-        .join("\n")
+    fn scrape_interval_secs(scrape_interval: Duration) -> u64 {
+        scrape_interval
+            .as_secs()
+            .max(Self::MIN_SCRAPE_INTERVAL_SECS)
     }
+
+    fn scrape_timeout_secs(scrape_interval_secs: u64) -> u64 {
+        scrape_interval_secs.saturating_sub(1).clamp(4, 10)
+    }
+
+    fn node_exporter_scrape_interval(scrape_interval: Duration) -> Duration {
+        Duration::from_secs(Self::scrape_interval_secs(scrape_interval).max(30))
+    }
+
+    fn validator_scrape_configuration(
+        metrics_path: &str,
+        targets: &[ScrapeTarget],
+        scrape_interval: Duration,
+    ) -> String {
+        let scrape_interval_secs = Self::scrape_interval_secs(scrape_interval);
+        let scrape_timeout_secs = Self::scrape_timeout_secs(scrape_interval_secs);
+        let mut config = vec![
+            "  - job_name: validators".to_string(),
+            format!("    metrics_path: {metrics_path}"),
+            "    honor_labels: true".to_string(),
+            format!("    scrape_interval: {scrape_interval_secs}s"),
+            format!("    scrape_timeout: {scrape_timeout_secs}s"),
+            format!("    sample_limit: {}", Self::VALIDATOR_SAMPLE_LIMIT),
+            "    static_configs:".to_string(),
+        ];
+        config.extend(
+            targets
+                .iter()
+                .flat_map(|target| {
+                    [
+                        "      - targets:".to_string(),
+                        format!("        - {}:{}", target.ip, target.port),
+                        "        labels:".to_string(),
+                        format!("          validator: {}", target.id),
+                    ]
+                })
+                .collect::<Vec<_>>(),
+        );
+        config.join("\n")
+    }
+
+    fn node_exporter_scrape_configuration(
+        targets: &[ScrapeTarget],
+        scrape_interval: Duration,
+    ) -> String {
+        let scrape_interval_secs = Self::scrape_interval_secs(scrape_interval);
+        let scrape_timeout_secs = Self::scrape_timeout_secs(scrape_interval_secs);
+        let mut config = vec![
+            "  - job_name: node-exporters".to_string(),
+            format!("    scrape_interval: {scrape_interval_secs}s"),
+            format!("    scrape_timeout: {scrape_timeout_secs}s"),
+            format!("    sample_limit: {}", Self::NODE_EXPORTER_SAMPLE_LIMIT),
+            "    static_configs:".to_string(),
+        ];
+        config.extend(
+            targets
+                .iter()
+                .flat_map(|target| {
+                    [
+                        "      - targets:".to_string(),
+                        format!("        - {}:9200", target.ip),
+                        "        labels:".to_string(),
+                        format!("          validator: {}", target.id),
+                    ]
+                })
+                .collect::<Vec<_>>(),
+        );
+        config.join("\n")
+    }
+
+    /// Parse one prometheus scrape target emitted by the protocol.
+    /// NOTE: The configuration file is a yaml file so spaces are important.
+    fn parse_scrape_target(id: &str, nodes_metrics_path: &str) -> ScrapeTarget {
+        let (address, path) = nodes_metrics_path.split_once('/').unwrap();
+        let address = address.parse::<SocketAddr>().unwrap();
+
+        ScrapeTarget {
+            id: id.to_string(),
+            ip: address.ip().to_string(),
+            port: address.port(),
+            metrics_path: format!("/{path}"),
+        }
+    }
+}
+
+struct ScrapeTarget {
+    id: String,
+    ip: String,
+    port: u16,
+    metrics_path: String,
 }
 
 pub struct Grafana;
@@ -727,7 +802,9 @@ impl NodeExporter {
 
 #[cfg(test)]
 mod tests {
-    use super::Prometheus;
+    use std::time::Duration;
+
+    use super::{Prometheus, ScrapeTarget};
 
     #[test]
     fn prometheus_reload_commands_copy_rules_and_reload() {
@@ -746,13 +823,57 @@ mod tests {
 
     #[test]
     fn prometheus_global_configuration_references_recording_rules() {
-        let config = Prometheus::global_configuration(60);
+        let config = Prometheus::global_configuration(Duration::from_secs(15));
 
-        assert!(config.contains("scrape_interval: 10s"));
-        assert!(config.contains("scrape_timeout: 5s"));
-        assert!(config.contains("evaluation_interval: 10s"));
+        assert!(config.contains("scrape_interval: 15s"));
+        assert!(config.contains("evaluation_interval: 15s"));
         assert!(config.contains("rule_files:"));
         assert!(config.contains("/etc/prometheus/recording_rules.yml"));
+    }
+
+    #[test]
+    fn prometheus_uses_shared_jobs_for_targets() {
+        let targets = vec![
+            ScrapeTarget {
+                id: "node-0".into(),
+                ip: "10.0.0.1".into(),
+                port: 1900,
+                metrics_path: "/metrics".into(),
+            },
+            ScrapeTarget {
+                id: "node-1".into(),
+                ip: "10.0.0.2".into(),
+                port: 1901,
+                metrics_path: "/metrics".into(),
+            },
+        ];
+
+        let validators = Prometheus::validator_scrape_configuration(
+            "/metrics",
+            &targets,
+            Duration::from_secs(15),
+        );
+        let exporters =
+            Prometheus::node_exporter_scrape_configuration(&targets, Duration::from_secs(30));
+
+        assert!(validators.contains("job_name: validators"));
+        assert_eq!(validators.matches("job_name:").count(), 1);
+        assert!(validators.contains("metrics_path: /metrics"));
+        assert!(validators.contains("scrape_interval: 15s"));
+        assert!(validators.contains("scrape_timeout: 10s"));
+        assert!(validators.contains("sample_limit: 50000"));
+        assert!(validators.contains("10.0.0.1:1900"));
+        assert!(validators.contains("10.0.0.2:1901"));
+        assert!(validators.contains("validator: node-0"));
+        assert!(validators.contains("validator: node-1"));
+
+        assert!(exporters.contains("job_name: node-exporters"));
+        assert_eq!(exporters.matches("job_name:").count(), 1);
+        assert!(exporters.contains("scrape_interval: 30s"));
+        assert!(exporters.contains("scrape_timeout: 10s"));
+        assert!(exporters.contains("sample_limit: 20000"));
+        assert!(exporters.contains("10.0.0.1:9200"));
+        assert!(exporters.contains("10.0.0.2:9200"));
     }
 
     #[test]

--- a/crates/orchestrator/src/monitor.rs
+++ b/crates/orchestrator/src/monitor.rs
@@ -178,8 +178,14 @@ impl Prometheus {
     fn ensure_runtime_flags_command() -> &'static str {
         "sudo sh -c 'file=/etc/default/prometheus; touch \"$file\"; \
             current=$(sed -n \"s/^ARGS=\\\"\\(.*\\)\\\"$/\\1/p\" \"$file\"); \
-            for flag in --web.enable-lifecycle --storage.tsdb.retention.time=30d --storage.tsdb.retention.size=100GB; do \
-                case \" $current \" in *\" $flag \"*) ;; *) current=\"${current:+$current }$flag\" ;; esac; \
+            for flag in \
+                --web.enable-lifecycle \
+                --storage.tsdb.retention.time=30d \
+                --storage.tsdb.retention.size=100GB; do \
+                case \" $current \" in \
+                    *\" $flag \"*) ;; \
+                    *) current=\"${current:+$current }$flag\" ;; \
+                esac; \
             done; \
             awk \"!/^ARGS=/\" \"$file\" > \"$file.tmp\"; \
             printf \"ARGS=\\\"%s\\\"\\n\" \"$current\" >> \"$file.tmp\"; \

--- a/crates/orchestrator/src/orchestrator.rs
+++ b/crates/orchestrator/src/orchestrator.rs
@@ -333,7 +333,8 @@ impl<P: ProtocolCommands + ProtocolMetrics> Orchestrator<P> {
                     .collect();
                 let sample_logs = self.sample_node_startup_logs(&stalled).await;
                 return Err(TestbedError::NodeBootError(format!(
-                    "{} of {} validators did not expose metrics within {}s.\nStartup log samples:\n{}",
+                    "{} of {} validators did not expose metrics within {}s.\n\
+                     Startup log samples:\n{}",
                     stalled.len(),
                     total,
                     timeout.as_secs(),

--- a/crates/orchestrator/src/orchestrator.rs
+++ b/crates/orchestrator/src/orchestrator.rs
@@ -610,6 +610,7 @@ impl<P: ProtocolCommands + ProtocolMetrics> Orchestrator<P> {
                 nodes,
                 ssh_manager,
                 self.settings.monitoring_working_dir(),
+                self.settings.monitoring_scrape_over_public_ip(),
             );
             let commands = &self.protocol_commands;
             monitor.start_prometheus(commands, parameters).await?;

--- a/crates/orchestrator/src/orchestrator.rs
+++ b/crates/orchestrator/src/orchestrator.rs
@@ -609,7 +609,6 @@ impl<P: ProtocolCommands + ProtocolMetrics> Orchestrator<P> {
                 nodes,
                 ssh_manager,
                 self.settings.monitoring_working_dir(),
-                self.settings.is_external_monitoring(),
             );
             let commands = &self.protocol_commands;
             monitor.start_prometheus(commands, parameters).await?;

--- a/crates/orchestrator/src/settings.rs
+++ b/crates/orchestrator/src/settings.rs
@@ -185,6 +185,12 @@ pub struct Settings {
     /// same public key as `ssh_private_key_file`.
     #[serde(default)]
     pub monitoring_server: Option<String>,
+    /// Override whether the monitoring Prometheus should scrape validator
+    /// public IPs. When unset, external monitoring servers default to public
+    /// IPs while orchestrator-managed monitoring instances follow the
+    /// benchmark's network mode.
+    #[serde(default)]
+    pub monitoring_scrape_public_ip: Option<bool>,
     /// The timeout duration for ssh commands (in seconds).
     #[serde(default = "defaults::default_ssh_timeout")]
     #[serde_as(as = "DurationSeconds")]
@@ -290,6 +296,13 @@ impl Settings {
     /// was specified in the `user@host` format.
     pub fn monitoring_ssh_user(&self) -> Option<&str> {
         self.parse_monitoring_server().and_then(|(user, _)| user)
+    }
+
+    /// Whether Prometheus should scrape validator public IPs from the
+    /// monitoring host.
+    pub fn monitoring_scrape_over_public_ip(&self) -> bool {
+        self.monitoring_scrape_public_ip
+            .unwrap_or(self.is_external_monitoring())
     }
 
     /// Return the isolated working directory for monitoring assets on the
@@ -522,5 +535,22 @@ mod test {
         assert_eq!(instance.id, EXTERNAL_MONITORING_ID);
         assert_eq!(instance.main_ip.to_string(), "127.0.0.1");
         assert_eq!(settings.monitoring_ssh_user(), Some("root"));
+    }
+
+    #[test]
+    fn external_monitoring_scrapes_public_ips_by_default() {
+        let mut settings = Settings::new_for_test();
+        settings.monitoring_server = Some("root@127.0.0.1".into());
+
+        assert!(settings.monitoring_scrape_over_public_ip());
+    }
+
+    #[test]
+    fn monitoring_scrape_public_ip_override_is_respected() {
+        let mut settings = Settings::new_for_test();
+        settings.monitoring_server = Some("root@127.0.0.1".into());
+        settings.monitoring_scrape_public_ip = Some(false);
+
+        assert!(!settings.monitoring_scrape_over_public_ip());
     }
 }

--- a/crates/starfish-core/Cargo.toml
+++ b/crates/starfish-core/Cargo.toml
@@ -37,6 +37,7 @@ tempfile = { workspace = true } # todo - move to dev-dep
 tidehunter = { git = "https://github.com/MystenLabs/tidehunter", rev = "cfe208a", optional = true }
 tokio = { workspace = true }
 tracing = { workspace = true }
+tower-http = { version = "0.6.8", features = ["compression-gzip"] }
 zeroize = "1.6.0"
 zstd = { version = "0.13.3", default-features = false }
 

--- a/crates/starfish-core/Cargo.toml
+++ b/crates/starfish-core/Cargo.toml
@@ -36,8 +36,8 @@ tabled = "0.12.2"
 tempfile = { workspace = true } # todo - move to dev-dep
 tidehunter = { git = "https://github.com/MystenLabs/tidehunter", rev = "cfe208a", optional = true }
 tokio = { workspace = true }
-tracing = { workspace = true }
 tower-http = { version = "0.6.8", features = ["compression-gzip"] }
+tracing = { workspace = true }
 zeroize = "1.6.0"
 zstd = { version = "0.13.3", default-features = false }
 

--- a/crates/starfish-core/src/prometheus.rs
+++ b/crates/starfish-core/src/prometheus.rs
@@ -7,6 +7,7 @@ use std::net::SocketAddr;
 use axum::{Extension, Router, http::StatusCode, routing::get};
 use prometheus::{Registry, TextEncoder};
 use tokio::net::TcpListener;
+use tower_http::compression::CompressionLayer;
 
 use crate::runtime::{Handle, JoinHandle};
 
@@ -18,6 +19,7 @@ pub fn start_prometheus_server(
 ) -> JoinHandle<Result<(), std::io::Error>> {
     let app = Router::new()
         .route(METRICS_ROUTE, get(metrics))
+        .layer(CompressionLayer::new())
         .layer(Extension(registry.clone()));
 
     tracing::info!("Prometheus server booted on {address}");


### PR DESCRIPTION
## Summary
- use fixed shared Prometheus scrape jobs instead of one job per node
- make external-monitoring scrape address selection explicit: external monitors default to public validator IPs, with an override for private-network deployments
- gzip Prometheus metrics responses to reduce scrape bandwidth

## Verification
- CARGO_TARGET_DIR=/tmp/starfish-verify-orch cargo test -p orchestrator -- --nocapture
- CARGO_TARGET_DIR=/tmp/starfish-verify-core cargo test -p starfish-core --no-run