### PR TITLE
fix(core): protocol-specific leader timeouts per pacemaker analysis

### DIFF
--- a/crates/orchestrator/src/client/vultr.rs
+++ b/crates/orchestrator/src/client/vultr.rs
@@ -244,7 +244,7 @@ impl ServerProviderClient for VultrClient {
     async fn delete_instance(&self, instance: Instance) -> CloudProviderResult<()> {
         let url = self
             .base_url
-            .join(&format!("instances/{}", &instance.id))
+            .join(&format!("instances/{}", instance.id))
             .unwrap();
 
         let response = self

--- a/crates/orchestrator/src/orchestrator.rs
+++ b/crates/orchestrator/src/orchestrator.rs
@@ -1913,7 +1913,7 @@ impl<P: ProtocolCommands + ProtocolMetrics> Orchestrator<P> {
                 display::config("Pre-built updated", updated_at);
             }
         } else {
-            display::config("Commit", format!("'{}'", &self.settings.repository.commit));
+            display::config("Commit", format!("'{}'", self.settings.repository.commit));
         }
         fs::create_dir_all(&self.suite_results_dir).expect("Failed to create results directory");
         display::config("Results directory", self.suite_results_dir.display());

--- a/crates/starfish-core/src/config.rs
+++ b/crates/starfish-core/src/config.rs
@@ -386,9 +386,12 @@ pub struct Parameters {
     /// Which storage backend to use for the DAG.
     #[serde(default)]
     pub storage_backend: StorageBackend,
-    /// Leader timeout for the consensus protocol.
-    #[serde(default = "param_defaults::default_leader_timeout")]
-    pub leader_timeout: Duration,
+    /// Leader timeout for the consensus protocol. When unset, each protocol
+    /// uses its pacemaker default: 2Δ for Push, 8Δ for Lazy-Push (see
+    /// `ConsensusProtocol::default_leader_timeout`). An explicit value
+    /// overrides the protocol default.
+    #[serde(default)]
+    pub leader_timeout: Option<Duration>,
     /// StarfishSpeed soft block-creation timeout (relaxed readiness).
     #[serde(default = "param_defaults::default_soft_block_timeout")]
     pub soft_block_timeout: Duration,
@@ -429,8 +432,15 @@ pub(crate) mod param_defaults {
         Duration::from_secs(10)
     }
 
+    /// Push pacemaker leader timeout: δ_LT = 2Δ with Δ = 300ms (Table III).
     pub fn default_leader_timeout() -> Duration {
         Duration::from_millis(600)
+    }
+
+    /// Lazy-Push pacemaker leader timeout: δ_LT = 8Δ with the same Δ = 300ms,
+    /// as the Lazy-Push liveness proof prescribes (Table III).
+    pub fn default_lazy_push_leader_timeout() -> Duration {
+        Duration::from_millis(2400)
     }
 
     pub fn default_soft_block_timeout() -> Duration {
@@ -446,7 +456,7 @@ impl Default for Parameters {
             initial_delay: param_defaults::default_initial_delay(),
             transaction_mode: TransactionMode::default(),
             storage_backend: StorageBackend::default(),
-            leader_timeout: param_defaults::default_leader_timeout(),
+            leader_timeout: None,
             soft_block_timeout: param_defaults::default_soft_block_timeout(),
             benchmark_duration: None,
         }

--- a/crates/starfish-core/src/cordial_knowledge.rs
+++ b/crates/starfish-core/src/cordial_knowledge.rs
@@ -920,7 +920,7 @@ impl DagKnowledgeInner {
         let from = after_round.saturating_add(1);
         for auth_dag in self.dag.iter_mut() {
             for (_, entries) in auth_dag.range_mut(from..) {
-                for (_, (_, known_by)) in entries.iter_mut() {
+                for (_, known_by) in entries.values_mut() {
                     *known_by &= bit;
                 }
             }

--- a/crates/starfish-core/src/crypto.rs
+++ b/crates/starfish-core/src/crypto.rs
@@ -676,7 +676,7 @@ impl Default for SignatureBytes {
 
 impl fmt::Debug for SignatureBytes {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "Sig({})", &hex::encode(&self.0[..4]))
+        write!(f, "Sig({})", hex::encode(&self.0[..4]))
     }
 }
 
@@ -800,7 +800,7 @@ impl<'de> Deserialize<'de> for BlsSignatureBytes {
 
 impl fmt::Debug for BlsSignatureBytes {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "BlsSig({})", &hex::encode(&self.0[..4]))
+        write!(f, "BlsSig({})", hex::encode(&self.0[..4]))
     }
 }
 
@@ -892,7 +892,7 @@ impl<'de> Deserialize<'de> for BlsPublicKey {
 
 impl fmt::Debug for BlsPublicKey {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "BlsPk({})", &hex::encode(&self.to_bytes()[..4]))
+        write!(f, "BlsPk({})", hex::encode(&self.to_bytes()[..4]))
     }
 }
 

--- a/crates/starfish-core/src/dag_state.rs
+++ b/crates/starfish-core/src/dag_state.rs
@@ -273,6 +273,20 @@ impl ConsensusProtocol {
             other => other,
         }
     }
+
+    /// Leader timeout prescribed by the pacemaker analysis (Table III):
+    /// δ_LT = 2Δ for the Push pacemaker and δ_LT = 8Δ for Lazy-Push, with
+    /// Δ = 300ms in this testbed. Starfish-BLS and Mysticeti-BLS instantiate
+    /// the Lazy-Push variants (Starfish-L, Mysticeti-L); all other protocols
+    /// use the Push pacemaker timeout.
+    pub fn default_leader_timeout(self) -> std::time::Duration {
+        match self {
+            ConsensusProtocol::StarfishBls | ConsensusProtocol::MysticetiBls => {
+                crate::config::param_defaults::default_lazy_push_leader_timeout()
+            }
+            _ => crate::config::param_defaults::default_leader_timeout(),
+        }
+    }
 }
 
 const STARFISH_SPEED_HINT_WINDOW_LEADER_ROUNDS: usize = 10;

--- a/crates/starfish-core/src/network.rs
+++ b/crates/starfish-core/src/network.rs
@@ -393,13 +393,10 @@ impl Worker {
                     work = self.connect_and_handle(delay, self.peer).boxed();
                 }
                 Either::Right((received, _work)) => {
-                    if let Some(received) = received {
-                        tracing::debug!("Replaced connection for {}", self.peer_id);
-                        work = self.handle_passive_stream(received).boxed();
-                    } else {
-                        // Channel closed, server is terminated
-                        return None;
-                    }
+                    // A closed channel means the server is terminated.
+                    let received = received?;
+                    tracing::debug!("Replaced connection for {}", self.peer_id);
+                    work = self.handle_passive_stream(received).boxed();
                 }
             }
         }

--- a/crates/starfish-core/src/validator.rs
+++ b/crates/starfish-core/src/validator.rs
@@ -76,8 +76,9 @@ impl Validator {
                 .register(Box::new(pc))
                 .wrap_err("Failed to register ProcessCollector")?;
         }
-        let resolved_dissemination = ConsensusProtocol::from_str(&consensus)
-            .resolve_dissemination_mode(public_config.parameters.dissemination_mode);
+        let protocol = ConsensusProtocol::from_str(&consensus);
+        let resolved_dissemination =
+            protocol.resolve_dissemination_mode(public_config.parameters.dissemination_mode);
         let dissemination_str = resolved_dissemination.to_string();
         let (metrics, reporter) = Metrics::new(
             &registry,
@@ -89,9 +90,13 @@ impl Validator {
         let metrics_handle =
             prometheus::start_prometheus_server(binding_metrics_address, &registry);
 
-        // Apply timeouts from Parameters to the consensus config.
+        // Apply timeouts from Parameters to the consensus config. An explicit
+        // leader timeout wins; otherwise use the protocol's pacemaker default
+        // (2Δ for Push, 8Δ for Lazy-Push; see Table III).
         let mut public_config = public_config;
-        public_config.parameters.leader_timeout = parameters.leader_timeout;
+        public_config.parameters.leader_timeout = parameters
+            .leader_timeout
+            .unwrap_or_else(|| protocol.default_leader_timeout());
         public_config.parameters.soft_block_timeout = parameters.soft_block_timeout;
 
         // Open the DAG state.


### PR DESCRIPTION
## Motivation

The pacemaker analysis (Table III of the Starfish paper) prescribes a leader timeout of 2Δ for the Push pacemaker and **8Δ for the Lazy-Push pacemaker**, but the testbed used 2Δ = 600 ms for every protocol. Benchmarks of the Lazy-Push instantiations therefore did not run the proof-prescribed timeout configuration (flagged in external review of the paper).

## Change

- `Parameters.leader_timeout` becomes `Option<Duration>`: an explicit value (YAML or programmatic) always wins; when unset, the protocol's pacemaker default applies.
- New `ConsensusProtocol::default_leader_timeout()`: 8Δ = 2400 ms for `StarfishBls` and `MysticetiBls` (the Lazy-Push instantiations of Starfish-L/Mysticeti-L), 2Δ = 600 ms for all other protocols.
- Resolution happens once, at `Validator::start`, which all run paths (local benchmark, dryrun, orchestrator) flow through.

## Behavior

- All-honest runs are unaffected: the leader timeout does not gate block creation when the leader-and-votes condition fires first.
- Fault/crash experiments with the BLS variants now use the proof-prescribed 8Δ.
- Every other protocol keeps byte-identical behavior; explicit `leader_timeout` settings in existing `parameters.yaml` files still deserialize and still override.

Out of scope: Bluestreak/Sparse-Starfish-Speed keep the 2Δ default — whether they should inherit the Lazy-Push timeout is a question for their own analysis, not this paper's.

## Testing

- `cargo check --workspace`, `cargo fmt --check`, `cargo clippy --all-targets`: clean.
- `cargo test -p starfish-core --lib`: 195/196 passed; `validator_sync::_bluestreak_260_expects` failed once under full parallel load and passes in isolation (pre-existing timing flake, unrelated — Bluestreak's timeout is unchanged).